### PR TITLE
[MX-1440] added functionality to access reference to WrappedComponents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ ReactDOM.render(
 );
 ```
 
+### Using the `withRef` parameter
+
+If you set `withRef = true` in the `options` object passed into `connectBackboneToReact`, you can get back a reference to the component you passed in using the instance method `.getWrappedComponent()` on the higher-order-component returned by `connectBackboneToReact(...)(Component)`.
+
 ## Rendering React Within Backbone.View
 
 This library's focus is on sharing Backbone.Models with React Components. It is not concerned with how to render React Components within Backbone.Views. [The React docs provide a possible implementation for this interopt.](https://reactjs.org/docs/integrating-with-other-libraries.html#embedding-react-in-a-backbone-view)

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -92,8 +92,8 @@ module.exports = function connectBackboneToReact(
         this.models = models;
       }
 
-      setWrappedComponent(ref) {
-        this.wrappedComponentRef = ref;
+      setWrappedComponent(component) {
+        this.wrappedComponentRef = component;
       }
 
       getWrappedComponent() {

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -29,6 +29,7 @@ module.exports = function connectBackboneToReact(
     debounce = false,
     events = {},
     modelTypes = {},
+    withRef = false,
   } = options;
 
   function getEventNames(modelName) {
@@ -69,8 +70,7 @@ module.exports = function connectBackboneToReact(
       constructor(props, context) {
         super(props, context);
 
-        const models = props.models || context.models;
-        this.setModels(models);
+        this.setModels(props, context);
 
         this.state = mapModelsToProps(this.models, this.props);
 
@@ -81,12 +81,23 @@ module.exports = function connectBackboneToReact(
           this.createNewProps = debounceFn(this.createNewProps, debounceWait);
         }
 
+        this.setWrappedComponent = this.setWrappedComponent.bind(this);
+
         this.createEventListeners();
       }
 
-      setModels(models) {
+      setModels(props, context) {
+        const models = Object.assign({}, context.models, props.models);
         validateModelTypes(models);
         this.models = models;
+      }
+
+      setWrappedComponent(ref) {
+        this.wrappedComponentRef = ref;
+      }
+
+      getWrappedComponent() {
+        return withRef ? this.wrappedComponentRef : new Error('Set the withRef parameter as true to get a reference to the WrappedComponent.');
       }
 
       createEventListeners() {
@@ -133,12 +144,6 @@ module.exports = function connectBackboneToReact(
         });
       }
 
-      componentWillReceiveProps(nextProps, nextContext) {
-        const models = nextProps.models || nextContext.models;
-        this.setModels(models);
-        this.createNewProps();
-      }
-
       componentWillUnmount() {
         if (debounce) {
           this.createNewProps.cancel();
@@ -163,6 +168,10 @@ module.exports = function connectBackboneToReact(
           this.state,
           this.props
         );
+
+        if (withRef) {
+          wrappedProps.ref = this.setWrappedComponent;
+        }
 
         // Don't pass through models prop.
         wrappedProps.models = undefined;

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -631,4 +631,45 @@ describe('connectBackboneToReact', function() {
       assert.equal(setStateSpy.called, false);
     });
   });
+
+  /* eslint-disable no-unused-vars */
+  describe('when returning refs from higher-order-component', function() {
+    beforeEach(function() {
+      const ConnectedTest = connectBackboneToReact(mapModelsToProps, {withRef: true})(TestComponent);
+
+      wrapper = mount(<ConnectedTest models={modelsMap} />);
+      stub = wrapper.find(TestComponent);
+    });
+
+    afterEach(function() {
+      wrapper.unmount();
+    });
+
+    it('returns a component passed in as result of the call to getWrappedObj', function() {
+      assert.ok(wrapper.instance().getWrappedComponent());
+    });
+
+    it('returns a component with equivalent properties to the component passed into connectBackboneToReact', function() {
+      assert.equal(wrapper.instance().getWrappedComponent().props, stub.node.props);
+      assert.equal(wrapper.instance().getWrappedComponent().updater, stub.node.updater);
+    });
+
+    it('returns the proper reference which can then be modified', function() {
+      assert.equal(wrapper.instance().getWrappedComponent().props, stub.node.props);
+      wrapper.instance().getWrappedComponent().props.changeName('newName');
+      assert.equal(wrapper.instance().getWrappedComponent().props, stub.node.props);
+    });
+
+    it('ensures that changes made to the wrapped component via enzyme are reflected in the ref to that component', function() {
+      assert.equal(wrapper.instance().getWrappedComponent().props, stub.node.props);
+      stub.node.props.changeName('anotherNewName');
+      assert.equal(wrapper.instance().getWrappedComponent().props, stub.node.props);
+    });
+
+    it('ensures that changes to the data model are reflected in the ref to the wrapped component', function() {
+      const newName = 'Banana';
+      userModel.set('name', newName);
+      assert.equal(wrapper.instance().getWrappedComponent().props.name, newName);
+    });
+  });
 });


### PR DESCRIPTION
Original issue: https://github.com/mongodb-js/connect-backbone-to-react/issues/18 

We want to be able to reference `WrappedComponents` directly, and we can do this as follows:

1. Add a `ref` attribute to the `WrappedComponent` that is returned by `ConnectBackboneToReact`'s `render` method; this attribute points to a callback function.
2. The callback, which will be executed after the component mounts, will receive the component as an argument. 
3. Inside the callback, save the component for future reference.
4. Access the component via the getter method, which ensures that the appropriate arguments are initially passed in.

Notes: some of the changes in this PR are reversing the last commit made on this fork's master; right now, this fork's master does not pass all the tests specified by `npm test` (I just checked out the second to last commit on the list of commits on master and the tests worked again). 